### PR TITLE
Integrity Shield Operator Update to 0.3.0 in OperatorHub.io 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -349,7 +349,7 @@ install-ishield: check-kubeconfig install-crds install-operator create-cr
 uninstall-ishield: delete-cr delete-operator
 
 create-ns:
-	@if [ "$(shell kubectl get ns integrity-shield-operator-system | sed -n '2 p' | awk '{print$$1}')" = integrity-shield-operator-system ]; then \
+	@if [ "$(shell kubectl get ns $(ISHIELD_NS) | sed -n '2 p' | awk '{print$$1}')" = $(ISHIELD_NS) ]; then \
 		echo namespace already exists !;  \
 	else  \
 		echo; \

--- a/Makefile
+++ b/Makefile
@@ -349,9 +349,13 @@ install-ishield: check-kubeconfig install-crds install-operator create-cr
 uninstall-ishield: delete-cr delete-operator
 
 create-ns:
-	@echo
-	@echo creating namespace
-	kubectl create ns $(ISHIELD_NS)
+	@if [ "$(shell kubectl get ns integrity-shield-operator-system | sed -n '2 p' | awk '{print$$1}')" = integrity-shield-operator-system ]; then \
+		echo namespace already exists !;  \
+	else  \
+		echo; \
+		echo creating namespace; \
+		kubectl create ns $(ISHIELD_NS); \
+	fi
 
 install-crds:
 	@echo installing crds
@@ -545,7 +549,6 @@ setup-olm-local:
 	$(ISHIELD_REPO_ROOT)/build/setup-olm-local.sh
 
 bundle-test-local:
-	make create-keyring-secret
 	make setup-tmp-cr
 	make setup-test-env
 	make e2e-test

--- a/build/clean-e2e-bundle-test-local.sh
+++ b/build/clean-e2e-bundle-test-local.sh
@@ -62,7 +62,7 @@ metadata:
   name: integrity-shield-operator
   namespace: ${ISHIELD_NS}
 spec:
-  channel: ${CHANNELS}
+  channel: ${ISHIELD_DEFAULT_CHANNEL}
   name: integrity-shield-operator
   source: integrity-shield-operator-catalog
   sourceNamespace: olm

--- a/build/clean-e2e-bundle-test-local.sh
+++ b/build/clean-e2e-bundle-test-local.sh
@@ -62,7 +62,7 @@ metadata:
   name: integrity-shield-operator
   namespace: ${ISHIELD_NS}
 spec:
-  channel: alpha
+  channel: ${CHANNELS}
   name: integrity-shield-operator
   source: integrity-shield-operator-catalog
   sourceNamespace: olm

--- a/build/deploy-bundle-local.sh
+++ b/build/deploy-bundle-local.sh
@@ -50,33 +50,6 @@ echo "-------------------------------------------------"
 echo "Install bundle catalogsource"
 
 cat <<EOF | kubectl create -f -
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: ${ISHIELD_NS}
----
-apiVersion: operators.coreos.com/v1
-kind: OperatorGroup
-metadata:
-  name: operatorgroup
-  namespace: ${ISHIELD_NS}
-spec:
-  targetNamespaces:
-  - ${ISHIELD_NS}
----
-apiVersion: operators.coreos.com/v1alpha1
-kind: Subscription
-metadata:
-  name: integrity-shield-operator
-  namespace: ${ISHIELD_NS}
-spec:
-  channel: ${CHANNELS}
-  installPlanApproval: Automatic
-  name: integrity-shield-operator
-  source: integrity-shield-operator-catalog
-  sourceNamespace: olm
-  startingCSV: ${STARTING_CSV}
----
 apiVersion: operators.coreos.com/v1alpha1
 kind: CatalogSource
 metadata:
@@ -90,4 +63,55 @@ spec:
   updateStrategy:
     registryPoll:
       interval: 15m
+EOF
+
+echo ""
+echo "-------------------------------------------------"
+echo "Check if integrity-shield-operator-catalog is deployed correctly."
+echo "Let's wait for integrity-shield-operator-catalog to be deployed..."
+while true; do
+   ISHIELD_STATUS=$(kubectl get pod -n olm 2>/dev/null | grep integrity-shield-operator-catalog | awk '{print $3}')
+   READY_STATUS=$(kubectl get pod -n olm 2>/dev/null | grep integrity-shield-operator-catalog | awk '{print $2}')
+   if [[ "$ISHIELD_STATUS" == "Running"  && "$READY_STATUS" == "1/1" ]]; then
+      echo
+      echo -n "===== Integrity Shield operator catalog has started, let's continue with installing subscription. ====="
+      echo
+      break
+   else
+      printf "."
+      sleep 2
+   fi
+done
+
+cat <<EOF | kubectl create -f -
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ${ISHIELD_NS}
+EOF
+
+cat <<EOF | kubectl create -f -
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: operatorgroup
+  namespace: ${ISHIELD_NS}
+spec:
+  targetNamespaces:
+  - ${ISHIELD_NS}
+EOF
+
+cat <<EOF | kubectl create -f -
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: integrity-shield-operator
+  namespace: ${ISHIELD_NS}
+spec:
+  channel: ${ISHIELD_DEFAULT_CHANNEL}
+  installPlanApproval: Automatic
+  name: integrity-shield-operator
+  source: integrity-shield-operator-catalog
+  sourceNamespace: olm
+  startingCSV: ${STARTING_CSV}
 EOF

--- a/build/deploy-bundle-local.sh
+++ b/build/deploy-bundle-local.sh
@@ -73,14 +73,14 @@ spec:
   channel: ${CHANNELS}
   installPlanApproval: Automatic
   name: integrity-shield-operator
-  source: new-integrity-shield-operator-catalog
+  source: integrity-shield-operator-catalog
   sourceNamespace: olm
   startingCSV: ${STARTING_CSV}
 ---
 apiVersion: operators.coreos.com/v1alpha1
 kind: CatalogSource
 metadata:
-  name: new-integrity-shield-operator-catalog
+  name: integrity-shield-operator-catalog
   namespace: olm
 spec:
   displayName: Integrity Ishield Operator

--- a/build/deploy-bundle-local.sh
+++ b/build/deploy-bundle-local.sh
@@ -70,17 +70,17 @@ metadata:
   name: integrity-shield-operator
   namespace: ${ISHIELD_NS}
 spec:
-  channel: alpha
+  channel: ${CHANNELS}
   installPlanApproval: Automatic
   name: integrity-shield-operator
-  source: integrity-shield-operator-catalog
+  source: new-integrity-shield-operator-catalog
   sourceNamespace: olm
   startingCSV: ${STARTING_CSV}
 ---
 apiVersion: operators.coreos.com/v1alpha1
 kind: CatalogSource
 metadata:
-  name: integrity-shield-operator-catalog
+  name: new-integrity-shield-operator-catalog
   namespace: olm
 spec:
   displayName: Integrity Ishield Operator

--- a/build/pull_images.sh
+++ b/build/pull_images.sh
@@ -53,9 +53,9 @@ echo -----------------------------
 echo ""
 
 
-# Push integrity-shield-logging image
+# Push integrity-shield-admission-controller image
 echo -----------------------------
-echo [2/3] Pulling integrity-shield-logging image.
+echo [2/3] Pulling integrity-shield-admission-controller image.
 docker pull ${ISHIELD_ADMISSION_CONTROLLER_IMAGE_NAME_AND_VERSION}
 echo done.
 echo -----------------------------

--- a/build/update-version.sh
+++ b/build/update-version.sh
@@ -35,9 +35,9 @@ else
    sedi=(-i)
 fi
 
-echo $SED
+
 sed "${sedi[@]}" "s|$PREV_VERSION|$VERSION|" ${ISHIELD_REPO_ROOT}/docs/ACM/README_DISABLE_ISHIELD_PROTECTION_ACM_ENV.md
-$SED -i  "s|$PREV_VERSION|$VERSION|" ${ISHIELD_REPO_ROOT}/scripts/install_shield.sh
-$SED -i  "s|$PREV_VERSION|$VERSION|" ${ISHIELD_REPO_ROOT}/COMPONENT_VERSION
-$SED -i "s|$PREV_VERSION|$VERSION|" ${SHIELD_OP_DIR}Makefile
-$SED -i  "s|$PREV_VERSION|$VERSION|" ${SHIELD_OP_DIR}config/manifests/bases/integrity-shield-operator.clusterserviceversion.yaml
+sed "${sedi[@]}" "s|$PREV_VERSION|$VERSION|" ${ISHIELD_REPO_ROOT}/scripts/install_shield.sh
+sed "${sedi[@]}" "s|$PREV_VERSION|$VERSION|" ${ISHIELD_REPO_ROOT}/COMPONENT_VERSION
+sed "${sedi[@]}" "s|$PREV_VERSION|$VERSION|" ${SHIELD_OP_DIR}Makefile
+sed "${sedi[@]}" "s|$PREV_VERSION|$VERSION|" ${SHIELD_OP_DIR}config/manifests/bases/integrity-shield-operator.clusterserviceversion.yaml

--- a/build/update-version.sh
+++ b/build/update-version.sh
@@ -28,16 +28,15 @@ fi
 
 OS_NAME=$(uname -s)
 
-SED=sed    
+
 if [[ "$OS_NAME" == "Darwin" ]]; then
-    SED=gsed
-    type $SED >/dev/null 2>&1 || {
-        echo >&2 "$SED it's not installed. Try: brew install gnu-sed" ;
-        exit 1;
-    }
+   sedi=(-i "")
+else
+   sedi=(-i)
 fi
 
-$SED -i  "s|$PREV_VERSION|$VERSION|" ${ISHIELD_REPO_ROOT}/docs/ACM/README_DISABLE_ISHIELD_PROTECTION_ACM_ENV.md
+echo $SED
+sed "${sedi[@]}" "s|$PREV_VERSION|$VERSION|" ${ISHIELD_REPO_ROOT}/docs/ACM/README_DISABLE_ISHIELD_PROTECTION_ACM_ENV.md
 $SED -i  "s|$PREV_VERSION|$VERSION|" ${ISHIELD_REPO_ROOT}/scripts/install_shield.sh
 $SED -i  "s|$PREV_VERSION|$VERSION|" ${ISHIELD_REPO_ROOT}/COMPONENT_VERSION
 $SED -i "s|$PREV_VERSION|$VERSION|" ${SHIELD_OP_DIR}Makefile

--- a/build/update-version.sh
+++ b/build/update-version.sh
@@ -26,15 +26,16 @@ if [ -z "$SHIELD_OP_DIR" ]; then
     exit 1
 fi
 
-sed -i "s|$PREV_VERSION|$VERSION|" ${ISHIELD_REPO_ROOT}/docs/ACM/README_DISABLE_ISHIELD_PROTECTION_ACM_ENV.md
-sed -i "s|$PREV_VERSION|$VERSION|" ${ISHIELD_REPO_ROOT}/scripts/install_shield.sh
-sed -i "s|$PREV_VERSION|$VERSION|" ${ISHIELD_REPO_ROOT}/COMPONENT_VERSION
-sed -i "s|$PREV_VERSION|$VERSION|" ${ISHIELD_REPO_ROOT}/develop/local-deploy/operator_local.yaml
-sed -i "s|$PREV_VERSION|$VERSION|" ${SHIELD_OP_DIR}Makefile
-sed -i "s|$PREV_VERSION|$VERSION|" ${SHIELD_OP_DIR}resources/testdata/deploymentForIShield.yaml
-sed -i "s|$PREV_VERSION|$VERSION|" ${SHIELD_OP_DIR}resources/testdata/integrityShieldCRForTest.yaml
-sed -i "s|$PREV_VERSION|$VERSION|" ${SHIELD_OP_DIR}resources/testdata/integrityShieldCR.yaml
-sed -i "s|$PREV_VERSION|$VERSION|" ${SHIELD_OP_DIR}resources/default-ishield-cr.yaml
-sed -i "s|$PREV_VERSION|$VERSION|" ${SHIELD_OP_DIR}config/manifests/bases/integrity-shield-operator.clusterserviceversion.yaml
-sed -i "s|$PREV_VERSION|$VERSION|" ${SHIELD_DIR}version/version.go
-sed -i "s|$PREV_VERSION|$VERSION|" ${SHIELD_DIR}pkg/util/mapnode/node_test.go
+if [[ "$OS_NAME" == "Linux" ]]; then
+    sed -i "s|$PREV_VERSION|$VERSION|" ${ISHIELD_REPO_ROOT}/docs/ACM/README_DISABLE_ISHIELD_PROTECTION_ACM_ENV.md
+    sed -i "s|$PREV_VERSION|$VERSION|" ${ISHIELD_REPO_ROOT}/scripts/install_shield.sh
+    sed -i "s|$PREV_VERSION|$VERSION|" ${ISHIELD_REPO_ROOT}/COMPONENT_VERSION
+    sed -i "s|$PREV_VERSION|$VERSION|" ${SHIELD_OP_DIR}Makefile
+    sed -i "s|$PREV_VERSION|$VERSION|" ${SHIELD_OP_DIR}config/manifests/bases/integrity-shield-operator.clusterserviceversion.yaml
+elif [[ "$OS_NAME" == "Darwin" ]]; then
+    sed -i '' "s|$PREV_VERSION|$VERSION|" ${ISHIELD_REPO_ROOT}/docs/ACM/README_DISABLE_ISHIELD_PROTECTION_ACM_ENV.md
+    sed -i '' "s|$PREV_VERSION|$VERSION|" ${ISHIELD_REPO_ROOT}/scripts/install_shield.sh
+    sed -i '' "s|$PREV_VERSION|$VERSION|" ${ISHIELD_REPO_ROOT}/COMPONENT_VERSION
+    sed -i '' "s|$PREV_VERSION|$VERSION|" ${SHIELD_OP_DIR}Makefile
+    sed -i '' "s|$PREV_VERSION|$VERSION|" ${SHIELD_OP_DIR}config/manifests/bases/integrity-shield-operator.clusterserviceversion.yaml
+fi

--- a/build/update-version.sh
+++ b/build/update-version.sh
@@ -26,16 +26,19 @@ if [ -z "$SHIELD_OP_DIR" ]; then
     exit 1
 fi
 
-if [[ "$OS_NAME" == "Linux" ]]; then
-    sed -i "s|$PREV_VERSION|$VERSION|" ${ISHIELD_REPO_ROOT}/docs/ACM/README_DISABLE_ISHIELD_PROTECTION_ACM_ENV.md
-    sed -i "s|$PREV_VERSION|$VERSION|" ${ISHIELD_REPO_ROOT}/scripts/install_shield.sh
-    sed -i "s|$PREV_VERSION|$VERSION|" ${ISHIELD_REPO_ROOT}/COMPONENT_VERSION
-    sed -i "s|$PREV_VERSION|$VERSION|" ${SHIELD_OP_DIR}Makefile
-    sed -i "s|$PREV_VERSION|$VERSION|" ${SHIELD_OP_DIR}config/manifests/bases/integrity-shield-operator.clusterserviceversion.yaml
-elif [[ "$OS_NAME" == "Darwin" ]]; then
-    sed -i '' "s|$PREV_VERSION|$VERSION|" ${ISHIELD_REPO_ROOT}/docs/ACM/README_DISABLE_ISHIELD_PROTECTION_ACM_ENV.md
-    sed -i '' "s|$PREV_VERSION|$VERSION|" ${ISHIELD_REPO_ROOT}/scripts/install_shield.sh
-    sed -i '' "s|$PREV_VERSION|$VERSION|" ${ISHIELD_REPO_ROOT}/COMPONENT_VERSION
-    sed -i '' "s|$PREV_VERSION|$VERSION|" ${SHIELD_OP_DIR}Makefile
-    sed -i '' "s|$PREV_VERSION|$VERSION|" ${SHIELD_OP_DIR}config/manifests/bases/integrity-shield-operator.clusterserviceversion.yaml
+OS_NAME=$(uname -s)
+
+SED=sed    
+if [[ "$OS_NAME" == "Darwin" ]]; then
+    SED=gsed
+    type $SED >/dev/null 2>&1 || {
+        echo >&2 "$SED it's not installed. Try: brew install gnu-sed" ;
+        exit 1;
+    }
 fi
+
+$SED -i  "s|$PREV_VERSION|$VERSION|" ${ISHIELD_REPO_ROOT}/docs/ACM/README_DISABLE_ISHIELD_PROTECTION_ACM_ENV.md
+$SED -i  "s|$PREV_VERSION|$VERSION|" ${ISHIELD_REPO_ROOT}/scripts/install_shield.sh
+$SED -i  "s|$PREV_VERSION|$VERSION|" ${ISHIELD_REPO_ROOT}/COMPONENT_VERSION
+$SED -i "s|$PREV_VERSION|$VERSION|" ${SHIELD_OP_DIR}Makefile
+$SED -i  "s|$PREV_VERSION|$VERSION|" ${SHIELD_OP_DIR}config/manifests/bases/integrity-shield-operator.clusterserviceversion.yaml

--- a/docs/ACM/README_DISABLE_ISHIELD_PROTECTION_ACM_ENV.md
+++ b/docs/ACM/README_DISABLE_ISHIELD_PROTECTION_ACM_ENV.md
@@ -39,9 +39,9 @@ You will use `policy-integrity-shield` to disable Integrity Shield protection in
                   name: integrity-shield-server
                 spec:
                   logger:
-                    image: quay.io/open-cluster-management/integrity-shield-logging:0.2.0
+                    image: quay.io/open-cluster-management/integrity-shield-logging:0.3.0
                   server:
-                    image: quay.io/open-cluster-management/integrity-shield-server:0.2.0
+                    image: quay.io/open-cluster-management/integrity-shield-server:0.3.0
       ```
 3.  Create signature annotation in `policy-integrity-shield.yaml` as below.
 

--- a/docs/ACM/README_DISABLE_ISHIELD_PROTECTION_ACM_ENV.md
+++ b/docs/ACM/README_DISABLE_ISHIELD_PROTECTION_ACM_ENV.md
@@ -39,9 +39,9 @@ You will use `policy-integrity-shield` to disable Integrity Shield protection in
                   name: integrity-shield-server
                 spec:
                   logger:
-                    image: quay.io/open-cluster-management/integrity-shield-logging:0.3.0
+                    image: quay.io/open-cluster-management/integrity-shield-logging:0.2.0
                   server:
-                    image: quay.io/open-cluster-management/integrity-shield-server:0.3.0
+                    image: quay.io/open-cluster-management/integrity-shield-server:0.2.0
       ```
 3.  Create signature annotation in `policy-integrity-shield.yaml` as below.
 

--- a/integrity-shield-operator/bundle.Dockerfile
+++ b/integrity-shield-operator/bundle.Dockerfile
@@ -21,7 +21,7 @@ LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
 LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
 LABEL operators.operatorframework.io.bundle.package.v1=integrity-shield-operator
 LABEL operators.operatorframework.io.bundle.channels.v1=alpha-0.3.0
-LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.12.0
+LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.10.0+git
 LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1
 LABEL operators.operatorframework.io.metrics.project_layout=go.kubebuilder.io/v3
 

--- a/integrity-shield-operator/bundle/manifests/apis.integrityshield.io_integrityshields.yaml
+++ b/integrity-shield-operator/bundle/manifests/apis.integrityshield.io_integrityshields.yaml
@@ -222,6 +222,18 @@ spec:
                             description: GMSACredentialSpecName is the name of the
                               GMSA credential spec to use.
                             type: string
+                          hostProcess:
+                            description: HostProcess determines if a container should
+                              be run as a 'Host Process' container. This field is
+                              alpha-level and will only be honored by components that
+                              enable the WindowsHostProcessContainers feature flag.
+                              Setting this field without the feature flag will result
+                              in errors when validating the Pod. All of a Pod's containers
+                              must have the same effective HostProcess value (it is
+                              not allowed to have a mix of HostProcess containers
+                              and non-HostProcess containers).  In addition, if HostProcess
+                              is true then HostNetwork must also be set to true.
+                            type: boolean
                           runAsUserName:
                             description: The UserName in Windows to run the entrypoint
                               of the container process. Defaults to the user specified
@@ -532,7 +544,7 @@ spec:
                                     field and the ones listed in the namespaces field.
                                     null selector and null or empty namespaces list
                                     means "this pod's namespace". An empty selector
-                                    ({}) matches all namespaces. This field is alpha-level
+                                    ({}) matches all namespaces. This field is beta-level
                                     and is only honored when PodAffinityNamespaceSelector
                                     feature is enabled.
                                   properties:
@@ -688,7 +700,7 @@ spec:
                                 the ones listed in the namespaces field. null selector
                                 and null or empty namespaces list means "this pod's
                                 namespace". An empty selector ({}) matches all namespaces.
-                                This field is alpha-level and is only honored when
+                                This field is beta-level and is only honored when
                                 PodAffinityNamespaceSelector feature is enabled.
                               properties:
                                 matchExpressions:
@@ -841,7 +853,7 @@ spec:
                                     field and the ones listed in the namespaces field.
                                     null selector and null or empty namespaces list
                                     means "this pod's namespace". An empty selector
-                                    ({}) matches all namespaces. This field is alpha-level
+                                    ({}) matches all namespaces. This field is beta-level
                                     and is only honored when PodAffinityNamespaceSelector
                                     feature is enabled.
                                   properties:
@@ -997,7 +1009,7 @@ spec:
                                 the ones listed in the namespaces field. null selector
                                 and null or empty namespaces list means "this pod's
                                 namespace". An empty selector ({}) matches all namespaces.
-                                This field is alpha-level and is only honored when
+                                This field is beta-level and is only honored when
                                 PodAffinityNamespaceSelector feature is enabled.
                               properties:
                                 matchExpressions:
@@ -1278,6 +1290,18 @@ spec:
                             description: GMSACredentialSpecName is the name of the
                               GMSA credential spec to use.
                             type: string
+                          hostProcess:
+                            description: HostProcess determines if a container should
+                              be run as a 'Host Process' container. This field is
+                              alpha-level and will only be honored by components that
+                              enable the WindowsHostProcessContainers feature flag.
+                              Setting this field without the feature flag will result
+                              in errors when validating the Pod. All of a Pod's containers
+                              must have the same effective HostProcess value (it is
+                              not allowed to have a mix of HostProcess containers
+                              and non-HostProcess containers).  In addition, if HostProcess
+                              is true then HostNetwork must also be set to true.
+                            type: boolean
                           runAsUserName:
                             description: The UserName in Windows to run the entrypoint
                               of the container process. Defaults to the user specified
@@ -1458,6 +1482,18 @@ spec:
                             description: GMSACredentialSpecName is the name of the
                               GMSA credential spec to use.
                             type: string
+                          hostProcess:
+                            description: HostProcess determines if a container should
+                              be run as a 'Host Process' container. This field is
+                              alpha-level and will only be honored by components that
+                              enable the WindowsHostProcessContainers feature flag.
+                              Setting this field without the feature flag will result
+                              in errors when validating the Pod. All of a Pod's containers
+                              must have the same effective HostProcess value (it is
+                              not allowed to have a mix of HostProcess containers
+                              and non-HostProcess containers).  In addition, if HostProcess
+                              is true then HostNetwork must also be set to true.
+                            type: boolean
                           runAsUserName:
                             description: The UserName in Windows to run the entrypoint
                               of the container process. Defaults to the user specified
@@ -1652,6 +1688,18 @@ spec:
                             description: GMSACredentialSpecName is the name of the
                               GMSA credential spec to use.
                             type: string
+                          hostProcess:
+                            description: HostProcess determines if a container should
+                              be run as a 'Host Process' container. This field is
+                              alpha-level and will only be honored by components that
+                              enable the WindowsHostProcessContainers feature flag.
+                              Setting this field without the feature flag will result
+                              in errors when validating the Pod. All of a Pod's containers
+                              must have the same effective HostProcess value (it is
+                              not allowed to have a mix of HostProcess containers
+                              and non-HostProcess containers).  In addition, if HostProcess
+                              is true then HostNetwork must also be set to true.
+                            type: boolean
                           runAsUserName:
                             description: The UserName in Windows to run the entrypoint
                               of the container process. Defaults to the user specified

--- a/integrity-shield-operator/bundle/manifests/integrity-shield-operator.clusterserviceversion.yaml
+++ b/integrity-shield-operator/bundle/manifests/integrity-shield-operator.clusterserviceversion.yaml
@@ -76,7 +76,7 @@ metadata:
         }
       ]
     capabilities: Basic Install
-    operators.operatorframework.io/builder: operator-sdk-v1.12.0
+    operators.operatorframework.io/builder: operator-sdk-v1.10.0+git
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     containerImage: quay.io/open-cluster-management/integrity-shield-operator:0.3.0
   name: integrity-shield-operator.v0.3.0
@@ -253,22 +253,7 @@ spec:
             - apiGroups:
                 - apis.integrityshield.io
               resources:
-                - integrityshieldren
                 - integrityshields
-              verbs:
-                - create
-                - delete
-                - get
-                - list
-                - patch
-                - update
-                - watch
-            - apiGroups:
-                - apis.integrityshield.io
-              resources:
-                - integrityshields
-                - integrityshields/finalizers
-                - manifestintegrityprofiles
               verbs:
                 - create
                 - delete
@@ -304,16 +289,6 @@ spec:
                 - update
                 - watch
             - apiGroups:
-                - coordination.k8s.io
-              resources:
-                - leases
-              verbs:
-                - create
-                - delete
-                - get
-                - list
-                - update
-            - apiGroups:
                 - ""
               resources:
                 - configmaps
@@ -321,18 +296,6 @@ spec:
                 - secrets
                 - serviceaccounts
                 - services
-              verbs:
-                - create
-                - delete
-                - get
-                - list
-                - patch
-                - update
-                - watch
-            - apiGroups:
-                - policy
-              resources:
-                - podsecuritypolicies
               verbs:
                 - create
                 - delete
@@ -476,4 +439,5 @@ spec:
   maturity: alpha
   provider:
     name: Community
+  replaces: integrity-shield-operator.v0.1.6
   version: 0.3.0

--- a/integrity-shield-operator/bundle/metadata/annotations.yaml
+++ b/integrity-shield-operator/bundle/metadata/annotations.yaml
@@ -5,7 +5,7 @@ annotations:
   operators.operatorframework.io.bundle.metadata.v1: metadata/
   operators.operatorframework.io.bundle.package.v1: integrity-shield-operator
   operators.operatorframework.io.bundle.channels.v1: alpha-0.3.0
-  operators.operatorframework.io.metrics.builder: operator-sdk-v1.12.0
+  operators.operatorframework.io.metrics.builder: operator-sdk-v1.10.0+git
   operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
   operators.operatorframework.io.metrics.project_layout: go.kubebuilder.io/v3
 

--- a/integrity-shield-operator/bundle/tests/scorecard/config.yaml
+++ b/integrity-shield-operator/bundle/tests/scorecard/config.yaml
@@ -12,9 +12,6 @@ stages:
     labels:
       suite: basic
       test: basic-check-spec-test
-    storage:
-      spec:
-        mountPath: {}
   - entrypoint:
     - scorecard-test
     - olm-bundle-validation
@@ -22,9 +19,6 @@ stages:
     labels:
       suite: olm
       test: olm-bundle-validation-test
-    storage:
-      spec:
-        mountPath: {}
   - entrypoint:
     - scorecard-test
     - olm-crds-have-validation
@@ -32,9 +26,6 @@ stages:
     labels:
       suite: olm
       test: olm-crds-have-validation-test
-    storage:
-      spec:
-        mountPath: {}
   - entrypoint:
     - scorecard-test
     - olm-crds-have-resources
@@ -42,9 +33,6 @@ stages:
     labels:
       suite: olm
       test: olm-crds-have-resources-test
-    storage:
-      spec:
-        mountPath: {}
   - entrypoint:
     - scorecard-test
     - olm-spec-descriptors
@@ -52,9 +40,6 @@ stages:
     labels:
       suite: olm
       test: olm-spec-descriptors-test
-    storage:
-      spec:
-        mountPath: {}
   - entrypoint:
     - scorecard-test
     - olm-status-descriptors
@@ -62,9 +47,3 @@ stages:
     labels:
       suite: olm
       test: olm-status-descriptors-test
-    storage:
-      spec:
-        mountPath: {}
-storage:
-  spec:
-    mountPath: {}

--- a/integrity-shield-operator/config/crd/bases/apis.integrityshield.io_integrityshields.yaml
+++ b/integrity-shield-operator/config/crd/bases/apis.integrityshield.io_integrityshields.yaml
@@ -155,6 +155,9 @@ spec:
                           gmsaCredentialSpecName:
                             description: GMSACredentialSpecName is the name of the GMSA credential spec to use.
                             type: string
+                          hostProcess:
+                            description: HostProcess determines if a container should be run as a 'Host Process' container. This field is alpha-level and will only be honored by components that enable the WindowsHostProcessContainers feature flag. Setting this field without the feature flag will result in errors when validating the Pod. All of a Pod's containers must have the same effective HostProcess value (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).  In addition, if HostProcess is true then HostNetwork must also be set to true.
+                            type: boolean
                           runAsUserName:
                             description: The UserName in Windows to run the entrypoint of the container process. Defaults to the user specified in image metadata if unspecified. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                             type: string
@@ -335,7 +338,7 @@ spec:
                                       type: object
                                   type: object
                                 namespaceSelector:
-                                  description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces. This field is alpha-level and is only honored when PodAffinityNamespaceSelector feature is enabled.
+                                  description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces. This field is beta-level and is only honored when PodAffinityNamespaceSelector feature is enabled.
                                   properties:
                                     matchExpressions:
                                       description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
@@ -420,7 +423,7 @@ spec:
                                   type: object
                               type: object
                             namespaceSelector:
-                              description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces. This field is alpha-level and is only honored when PodAffinityNamespaceSelector feature is enabled.
+                              description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces. This field is beta-level and is only honored when PodAffinityNamespaceSelector feature is enabled.
                               properties:
                                 matchExpressions:
                                   description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
@@ -504,7 +507,7 @@ spec:
                                       type: object
                                   type: object
                                 namespaceSelector:
-                                  description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces. This field is alpha-level and is only honored when PodAffinityNamespaceSelector feature is enabled.
+                                  description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces. This field is beta-level and is only honored when PodAffinityNamespaceSelector feature is enabled.
                                   properties:
                                     matchExpressions:
                                       description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
@@ -589,7 +592,7 @@ spec:
                                   type: object
                               type: object
                             namespaceSelector:
-                              description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces. This field is alpha-level and is only honored when PodAffinityNamespaceSelector feature is enabled.
+                              description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces. This field is beta-level and is only honored when PodAffinityNamespaceSelector feature is enabled.
                               properties:
                                 matchExpressions:
                                   description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
@@ -777,6 +780,9 @@ spec:
                           gmsaCredentialSpecName:
                             description: GMSACredentialSpecName is the name of the GMSA credential spec to use.
                             type: string
+                          hostProcess:
+                            description: HostProcess determines if a container should be run as a 'Host Process' container. This field is alpha-level and will only be honored by components that enable the WindowsHostProcessContainers feature flag. Setting this field without the feature flag will result in errors when validating the Pod. All of a Pod's containers must have the same effective HostProcess value (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).  In addition, if HostProcess is true then HostNetwork must also be set to true.
+                            type: boolean
                           runAsUserName:
                             description: The UserName in Windows to run the entrypoint of the container process. Defaults to the user specified in image metadata if unspecified. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                             type: string
@@ -892,6 +898,9 @@ spec:
                           gmsaCredentialSpecName:
                             description: GMSACredentialSpecName is the name of the GMSA credential spec to use.
                             type: string
+                          hostProcess:
+                            description: HostProcess determines if a container should be run as a 'Host Process' container. This field is alpha-level and will only be honored by components that enable the WindowsHostProcessContainers feature flag. Setting this field without the feature flag will result in errors when validating the Pod. All of a Pod's containers must have the same effective HostProcess value (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).  In addition, if HostProcess is true then HostNetwork must also be set to true.
+                            type: boolean
                           runAsUserName:
                             description: The UserName in Windows to run the entrypoint of the container process. Defaults to the user specified in image metadata if unspecified. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                             type: string
@@ -1016,6 +1025,9 @@ spec:
                           gmsaCredentialSpecName:
                             description: GMSACredentialSpecName is the name of the GMSA credential spec to use.
                             type: string
+                          hostProcess:
+                            description: HostProcess determines if a container should be run as a 'Host Process' container. This field is alpha-level and will only be honored by components that enable the WindowsHostProcessContainers feature flag. Setting this field without the feature flag will result in errors when validating the Pod. All of a Pod's containers must have the same effective HostProcess value (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).  In addition, if HostProcess is true then HostNetwork must also be set to true.
+                            type: boolean
                           runAsUserName:
                             description: The UserName in Windows to run the entrypoint of the container process. Defaults to the user specified in image metadata if unspecified. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                             type: string

--- a/integrity-shield-operator/config/manifests/bases/integrity-shield-operator.clusterserviceversion.yaml
+++ b/integrity-shield-operator/config/manifests/bases/integrity-shield-operator.clusterserviceversion.yaml
@@ -4,7 +4,7 @@ metadata:
   annotations:
     alm-examples: '[]'
     capabilities: Basic Install
-  name: integrity-shield-operator.v0.0.0
+  name: integrity-shield-operator.v0.3.0
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -46,4 +46,4 @@ spec:
   maturity: alpha
   provider:
     name: Community
-  version: 0.0.0
+  version: 0.3.0

--- a/ishield-build.conf
+++ b/ishield-build.conf
@@ -7,6 +7,7 @@ ISHIELD_VERSION=0.3.0
 VERSION=0.3.0
 PREV_VERSION=0.1.6
 CHANNELS=alpha-0.3.0
+ISHIELD_DEFAULT_CHANNEL=alpha-0.3.0
 
 ISHIELD_NS=integrity-shield-operator-system
 

--- a/ishield-build.conf
+++ b/ishield-build.conf
@@ -5,7 +5,7 @@ LOCAL_BUNDLE_REGISTRY=localhost:5000
 
 ISHIELD_VERSION=0.3.0
 VERSION=0.3.0
-PREV_VERSION=0.0.0
+PREV_VERSION=0.1.6
 CHANNELS=alpha-0.3.0
 
 ISHIELD_NS=integrity-shield-operator-system
@@ -48,5 +48,6 @@ TEST_ASSET_ETCD=${ISHIELD_REPO_ROOT}/integrity-shield-operator/testbin/bin/etcd
 TEST_ASSET_KUBECTL=${ISHIELD_REPO_ROOT}/integrity-shield-operator/testbin/bin/kubectl
 TEST_ASSET_KUBE_APISERVER=${ISHIELD_REPO_ROOT}/integrity-shield-operator/testbin/bin/kube-apiserver
 
-OLM_VERSION=v0.17.0
+OLM_VERSION=v0.19.1
 OLM_RELEASE_URL=https://github.com/operator-framework/operator-lifecycle-manager/releases/download
+

--- a/scripts/install_shield.sh
+++ b/scripts/install_shield.sh
@@ -39,7 +39,7 @@ if [ -z "$ISHIELD_REPO_ROOT" ]; then
     exit 1
 fi
 
-IMG=quay.io/open-cluster-management/integrity-shield-operator:0.2.0
+IMG=quay.io/open-cluster-management/integrity-shield-operator:0.3.0
 SHIELD_OP_DIR=${ISHIELD_REPO_ROOT}"/integrity-shield-operator/"
 
 echo ""


### PR DESCRIPTION
Signed-off-by: Kugamoorthy Gajananan gajan@jp.ibm.com

This PR address the following implementation :

Prepare operator bundle ready for submitting to OperatorHub.io
*  fixed Makefile,scripts for generating bundle for local olm test, generated new bundle
*  fixed previous version, replaces in CSV
*  changed to operator-sdk version v1.10.1 to deal validation test issue
